### PR TITLE
Remove height from images

### DIFF
--- a/images.html
+++ b/images.html
@@ -40,13 +40,13 @@
       <br><br>
 
    <img src="yfu.PNG"
-     alt="angelina" width="370" height="370" id="profile2" align="left">
+     alt="angelina" width="370" id="profile2" align="left">
 
    <img src="jackmaddieandme.JPG"
-    alt="angelina" width="370" height="370" id="profile" align="center">
+    alt="angelina" width="370" id="profile" align="center">
 
  <img src="christineandrienneandme.JPG"
-  alt="angelina" width="370" height="370" id="profile" align="center">
+  alt="angelina" width="370" id="profile" align="center">
 </p>
 
 


### PR DESCRIPTION
This'll make it so the images are scaled correctly!  When you just mandate the `width`, then you don't have to do the height, and then images won't look squished. :)
